### PR TITLE
feat: add addressHexToBech32 for Helios→CardanoSDK migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.4.24",
+    "version": "6.4.25",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@koralabs/kora-labs-common",
-            "version": "6.4.24",
+            "version": "6.4.25",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-kms": "^3.1003.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.4.25",
+    "version": "6.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@koralabs/kora-labs-common",
-            "version": "6.4.25",
+            "version": "6.6.0",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-kms": "^3.1003.0",
+                "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
                 "bech32": "^2.0.0",
                 "blakejs": "^1.2.1",
                 "boolean": "^3.2.0",
@@ -3910,6 +3911,12 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@emurgo/cardano-message-signing-nodejs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emurgo/cardano-message-signing-nodejs/-/cardano-message-signing-nodejs-1.1.0.tgz",
+            "integrity": "sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ==",
+            "license": "MIT"
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.5.0",
+    "version": "6.6.0",
     "description": "Kora Labs Common Utilities",
     "main": "index.js",
     "types": "index.d.ts",
@@ -40,6 +40,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-kms": "^3.1003.0",
+        "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
         "bech32": "^2.0.0",
         "blakejs": "^1.2.1",
         "boolean": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.4.25",
+    "version": "6.5.0",
     "description": "Kora Labs Common Utilities",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/utils/cip8/index.test.ts
+++ b/src/utils/cip8/index.test.ts
@@ -1,0 +1,89 @@
+import { verifyCip30SignData } from '.';
+
+// ---- Fixture generation ----
+// These fixtures were generated using @emurgo/cardano-message-signing-nodejs
+// with a real Ed25519 key pair, signing the payload "test-request-id$alice"
+// with a fake testnet address 0x00aa. The COSE structures match what a
+// CIP-30 wallet would produce.
+const generateFixture = async () => {
+    const cms = await import('@emurgo/cardano-message-signing-nodejs');
+    const crypto = await import('crypto');
+
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const pubKeyRaw = publicKey.export({ type: 'spki', format: 'der' }).subarray(12);
+
+    const payloadText = 'test-request-id$alice';
+    const payloadBytes = Buffer.from(payloadText);
+    const addressHex = '00aa';
+    const addressBytes = Buffer.from(addressHex, 'hex');
+
+    const protectedHeaders = cms.HeaderMap.new();
+    protectedHeaders.set_algorithm_id(cms.Label.from_algorithm_id(cms.AlgorithmId.EdDSA));
+    protectedHeaders.set_header(cms.Label.new_text('address'), cms.CBORValue.new_bytes(addressBytes));
+
+    const headers = cms.Headers.new(cms.ProtectedHeaderMap.new(protectedHeaders), cms.HeaderMap.new());
+    const builder = cms.COSESign1Builder.new(headers, payloadBytes, false);
+    const sigStructureBytes = builder.make_data_to_sign().to_bytes();
+    const signature = crypto.sign(null, Buffer.from(sigStructureBytes), privateKey);
+    const coseSign1 = builder.build(signature);
+
+    const coseKey = cms.COSEKey.new(cms.Label.from_key_type(cms.KeyType.OKP));
+    coseKey.set_algorithm_id(cms.Label.from_algorithm_id(cms.AlgorithmId.EdDSA));
+    coseKey.set_header(cms.Label.new_int(cms.Int.new_i32(-1)), cms.CBORValue.from_label(cms.Label.from_curve_type(cms.CurveType.Ed25519)));
+    coseKey.set_header(cms.Label.new_int(cms.Int.new_i32(-2)), cms.CBORValue.new_bytes(pubKeyRaw));
+
+    return {
+        signatureCborHex: Buffer.from(coseSign1.to_bytes()).toString('hex'),
+        publicKeyCborHex: Buffer.from(coseKey.to_bytes()).toString('hex'),
+        payloadHex: payloadBytes.toString('hex'),
+        addressHex
+    };
+};
+
+describe('verifyCip30SignData', () => {
+    it('should verify a valid CIP-30 signature', async () => {
+        const fixture = await generateFixture();
+        const result = await verifyCip30SignData(
+            fixture.signatureCborHex,
+            fixture.publicKeyCborHex,
+            fixture.payloadHex,
+            fixture.addressHex
+        );
+        expect(result).toBe(true);
+    });
+
+    it('should reject when payload does not match', async () => {
+        const fixture = await generateFixture();
+        const result = await verifyCip30SignData(
+            fixture.signatureCborHex,
+            fixture.publicKeyCborHex,
+            Buffer.from('wrong-payload').toString('hex'),
+            fixture.addressHex
+        );
+        expect(result).toBe(false);
+    });
+
+    it('should reject when address does not match', async () => {
+        const fixture = await generateFixture();
+        const result = await verifyCip30SignData(
+            fixture.signatureCborHex,
+            fixture.publicKeyCborHex,
+            fixture.payloadHex,
+            'deadbeef'
+        );
+        expect(result).toBe(false);
+    });
+
+    it('should reject a tampered signature', async () => {
+        const fixture = await generateFixture();
+        // Flip a byte in the signature CBOR (the signature field is near the end)
+        const tampered = fixture.signatureCborHex.slice(0, -4) + 'ffff';
+        const result = await verifyCip30SignData(
+            tampered,
+            fixture.publicKeyCborHex,
+            fixture.payloadHex,
+            fixture.addressHex
+        );
+        expect(result).toBe(false);
+    });
+});

--- a/src/utils/cip8/index.ts
+++ b/src/utils/cip8/index.ts
@@ -1,0 +1,83 @@
+import { createPublicKey, verify } from 'crypto';
+
+let _cms: typeof import('@emurgo/cardano-message-signing-nodejs') | undefined;
+
+const getCms = async () => {
+    if (!_cms) {
+        _cms = await import('@emurgo/cardano-message-signing-nodejs');
+    }
+    return _cms;
+};
+
+/**
+ * Verify a CIP-30 signData (CIP-8) signature.
+ *
+ * Parses the COSE structures produced by the wallet, reconstructs the
+ * SigStructure using the library (not manual CBOR), and verifies the
+ * Ed25519 signature with Node.js crypto.
+ *
+ * @param signatureCborHex - COSESign1 CBOR hex from wallet signData response
+ * @param publicKeyCborHex - COSEKey CBOR hex from wallet signData response
+ * @param expectedPayloadHex - hex of the expected signed payload (e.g. requestId + handle as UTF-8 bytes)
+ * @param expectedAddressHex - hex of the expected signing address (must match the address in the COSE protected headers)
+ * @returns true if the signature is valid
+ */
+export const verifyCip30SignData = async (
+    signatureCborHex: string,
+    publicKeyCborHex: string,
+    expectedPayloadHex: string,
+    expectedAddressHex: string
+): Promise<boolean> => {
+    const cms = await getCms();
+
+    // Parse COSESign1 and COSEKey from wallet output
+    const coseSign1 = cms.COSESign1.from_bytes(Buffer.from(signatureCborHex, 'hex'));
+    const coseKey = cms.COSEKey.from_bytes(Buffer.from(publicKeyCborHex, 'hex'));
+
+    // Extract the address from the protected headers and verify it matches
+    const protectedHeaders = coseSign1.headers().protected().deserialized_headers();
+    const addressLabel = cms.Label.new_text('address');
+    const addressValue = protectedHeaders.header(addressLabel);
+    if (addressValue) {
+        const addressBytes = Buffer.from(addressValue.as_bytes() ?? new Uint8Array()).toString('hex');
+        if (addressBytes !== expectedAddressHex) {
+            return false;
+        }
+    }
+
+    // Verify the payload matches what we expect
+    const signedPayload = coseSign1.payload();
+    if (signedPayload) {
+        const payloadHex = Buffer.from(signedPayload).toString('hex');
+        if (payloadHex !== expectedPayloadHex) {
+            return false;
+        }
+    }
+
+    // Reconstruct the SigStructure (what was actually signed) using the library
+    const sigStructure = coseSign1.signed_data();
+    const sigStructureBytes = sigStructure.to_bytes();
+
+    // Extract the raw Ed25519 signature
+    const signatureBytes = coseSign1.signature();
+
+    // Extract the Ed25519 public key from COSEKey (label -2 is the "x" coordinate / public key)
+    const xLabel = cms.Label.new_int(cms.Int.new_i32(-2));
+    const pubKeyValue = coseKey.header(xLabel);
+    if (!pubKeyValue) {
+        return false;
+    }
+    const pubKeyBytes = pubKeyValue.as_bytes();
+    if (!pubKeyBytes || pubKeyBytes.length !== 32) {
+        return false;
+    }
+
+    // Wrap the raw Ed25519 public key in DER SPKI format for Node.js crypto
+    const pubKeyDer = Buffer.concat([
+        Buffer.from('302a300506032b6570032100', 'hex'),
+        Buffer.from(pubKeyBytes)
+    ]);
+    const keyObject = createPublicKey({ key: pubKeyDer, format: 'der', type: 'spki' });
+
+    return verify(null, Buffer.from(sigStructureBytes), keyObject, Buffer.from(signatureBytes));
+};

--- a/src/utils/crypto/crypto.test.ts
+++ b/src/utils/crypto/crypto.test.ts
@@ -1,4 +1,4 @@
-import { bech32FromHex, buildHolderInfo, buildPaymentAddressType, buildStakeKey, getPaymentKeyHash } from '.';
+import { addressHexToBech32, bech32FromHex, buildHolderInfo, buildPaymentAddressType, buildStakeKey, decodeAddress, getPaymentKeyHash } from '.';
 import { AddressType } from '../../types';
 
 const addresses = ['addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x', 'addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh', 'addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve', 'addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g', 'addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5pnz75xxcrzqf96k', 'addr128phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtupnz75xxcrtw79hu', 'addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8', 'addr1w8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcyjy7wx', 'stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw', 'stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5'];
@@ -107,6 +107,40 @@ describe('addresses tests', () => {
         });
     });
 });
+
+    describe('addressHexToBech32', () => {
+        it('should convert a testnet payment address hex to bech32', () => {
+            const hex = '007ad324c4fb08709dd997f6b2ba7980d5007103a2aa3f7a7eb8b44bc6f1a8e379127b811583070faf74db00d880d45027fe6171b1b69bd9ca';
+            const result = addressHexToBech32(hex);
+            expect(result).toEqual('addr_test1qpadxfxylvy8p8wejlmt9wnesr2squgr524r77n7hz6yh3h34r3hjynmsy2cxpc04a6dkqxcsr29qfl7v9cmrd5mm89qqh563f');
+        });
+
+        it('should convert a mainnet payment address hex to bech32', () => {
+            // addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x
+            const hex = decodeAddress('addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x');
+            expect(hex).not.toBeNull();
+            const result = addressHexToBech32(hex!);
+            expect(result).toEqual('addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x');
+        });
+
+        it('should convert a testnet stake address hex to bech32', () => {
+            const hex = decodeAddress('stake_test1uq4krgsmaj7xkvveh260pa024whuc58tslk0tnyyx3javfg36sly7');
+            expect(hex).not.toBeNull();
+            const result = addressHexToBech32(hex!);
+            expect(result).toEqual('stake_test1uq4krgsmaj7xkvveh260pa024whuc58tslk0tnyyx3javfg36sly7');
+        });
+
+        it('should convert a mainnet stake address hex to bech32', () => {
+            const hex = decodeAddress('stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw');
+            expect(hex).not.toBeNull();
+            const result = addressHexToBech32(hex!);
+            expect(result).toEqual('stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw');
+        });
+
+        it('should return empty string for empty hex', () => {
+            expect(addressHexToBech32('')).toEqual('');
+        });
+    });
 
 // TODO: Add test for verifySignature
 // describe.skip('verifySignature tests', () => { 

--- a/src/utils/crypto/index.ts
+++ b/src/utils/crypto/index.ts
@@ -247,6 +247,20 @@ export const getSlotNumberFromDate = (date: Date): number => {
     return (Math.floor(date.getTime() / 1000) - 1596491091) + 4924800;
 };
 
+export const addressHexToBech32 = (hex: string): string => {
+    const bytes = Uint8Array.from(Buffer.from(hex, 'hex'));
+    if (bytes.length === 0) return '';
+    const header = bytes[0];
+    const addressType = header >> 4;
+    const networkId = header & 0x0f;
+    const isTestnet = networkId === 0;
+    const isReward = addressType === 14 || addressType === 15;
+    const type: 'addr' | 'stake' = isReward ? 'stake' : 'addr';
+    const prefix = isTestnet && (type === 'addr' || type === 'stake') ? `${type}_test` : type;
+    const words = bech32.toWords(bytes);
+    return bech32.encode(prefix, words, 2048);
+};
+
 export const blake2b = (input: string | Buffer | Uint8Array, outlen = 32) => {
     if (typeof input == 'string') {
         input = Buffer.from(input, 'hex');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -191,4 +191,5 @@ export const buildUserIssueEventKey = (
 
 export { decodeCborToJson, encodeJsonToDatum, DefaultTextFormat as KeyType } from './cbor';
 
+export * from './cip8';
 export * from './crypto';


### PR DESCRIPTION
## Summary
- **`addressHexToBech32(hex)`** — reads the header byte to auto-determine bech32 prefix (`addr`/`addr_test`/`stake`/`stake_test`), unlike `bech32FromHex` which needs explicit params
- **`verifyCip30SignData(signatureCbor, publicKeyCbor, payload, address)`** — CIP-8 signature verification using `@emurgo/cardano-message-signing-nodejs` (standalone WASM, zero CSL dependency). Parses COSESign1/COSEKey properly via the library's `signed_data()` method instead of manual CBOR reconstruction — eliminates wallet-specific bugs from encoding differences
- Version bump `6.4.25` → `6.6.0` (new public APIs + new dependency)

## New dependency
- `@emurgo/cardano-message-signing-nodejs ^1.0.1` — 276KB standalone WASM, zero npm dependencies, no CSL

## Test plan
- [x] 5 tests for `addressHexToBech32`: mainnet/testnet payment+stake addresses, empty hex
- [x] 4 tests for `verifyCip30SignData`: valid signature, wrong payload, wrong address, tampered signature
- [x] All 92 tests pass
- [x] Clean `tsc` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)