### PR TITLE
test(handles): add HandlesApi coverage

### DIFF
--- a/src/handles/api.test.ts
+++ b/src/handles/api.test.ts
@@ -1,0 +1,73 @@
+import { HandlesApi } from './api';
+import { HANDLES_API_KEY, KORA_USER_AGENT } from './constants';
+
+const originalFetch = global.fetch;
+
+describe('HandlesApi', () => {
+    afterEach(() => {
+        global.fetch = originalFetch;
+        HandlesApi.init({network: 'mainnet'});
+    });
+
+    it('requires initialization before making API requests', async () => {
+        (HandlesApi as unknown as {_host?: string})._host = undefined;
+
+        await expect(HandlesApi.apiRequest('/handles/test')).rejects.toThrow(
+            'HandlesApi has not been initialized. Please call HandlesApi.init(<network>)'
+        );
+    });
+
+    it('selects the mainnet API host by default and applies default headers', async () => {
+        const json = jest.fn().mockResolvedValue({handle: 'test'});
+        const fetchMock = jest.fn().mockResolvedValue({json});
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        HandlesApi.init();
+
+        await expect(HandlesApi.apiRequest('/handles/test')).resolves.toEqual({handle: 'test'});
+        expect(fetchMock).toHaveBeenCalledWith('https://api.handle.me/handles/test', {
+            headers: {
+                Accepts: 'application/json',
+                'User-Agent': KORA_USER_AGENT,
+                'api-key': HANDLES_API_KEY
+            }
+        });
+    });
+
+    it('selects a network-specific API host', async () => {
+        const json = jest.fn().mockResolvedValue({handle: 'preview'});
+        const fetchMock = jest.fn().mockResolvedValue({json});
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        HandlesApi.init({network: 'preview'});
+
+        await HandlesApi.apiRequest('/handles/preview');
+        expect(fetchMock).toHaveBeenCalledWith('https://preview.api.handle.me/handles/preview', expect.any(Object));
+    });
+
+    it('uses a supplied host and headers unchanged', async () => {
+        const json = jest.fn().mockResolvedValue({ok: true});
+        const fetchMock = jest.fn().mockResolvedValue({json});
+        const headers = {'x-test': 'yes'};
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        HandlesApi.init({host: 'https://handles.internal'});
+
+        await HandlesApi.apiRequest('/health', headers);
+        expect(fetchMock).toHaveBeenCalledWith('https://handles.internal/health', {headers});
+    });
+
+    it('requires a handle and patches the policy on getHandle responses', async () => {
+        const json = jest.fn().mockResolvedValue({handle: 'test'});
+        const fetchMock = jest.fn().mockResolvedValue({json});
+        global.fetch = fetchMock as unknown as typeof fetch;
+        HandlesApi.init({host: 'https://handles.internal'});
+
+        await expect(HandlesApi.getHandle('')).rejects.toThrow('handle is required');
+        await expect(HandlesApi.getHandle('test')).resolves.toEqual({
+            handle: 'test',
+            policy: 'f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a'
+        });
+        expect(fetchMock).toHaveBeenCalledWith('https://handles.internal/handles/test', expect.any(Object));
+    });
+});

--- a/test_coverage.report
+++ b/test_coverage.report
@@ -1,80 +1,74 @@
 FORMAT_VERSION=1
 REPO=kora-labs-common
-TIMESTAMP_UTC=2026-02-22T20:27:00Z
+TIMESTAMP_UTC=2026-05-16T13:04:44Z
 THRESHOLD_LINES=90
 THRESHOLD_BRANCHES=90
 TOTAL_LINES_PCT=100
 TOTAL_BRANCHES_PCT=100
 STATUS=pass
-SOURCE_PATHS=src/constants/{contractsRegistry.ts,mintedOgList.ts};src/errors/index.ts;src/handles/interfaces/index.ts;src/types/{index.ts,profile-header.ts};src/utils/cbor/schema/{designer.ts,handleData.ts,marketplaceDatum.ts,portal.ts,socials.ts,subHandleSettings.ts}
-EXCLUDED_PATHS=src/{environment/**,http/**,logger/**,marketplace/**,repositories/**,protectedWords/**}:covered-by-existing-unit-suites-but-not-in-guardrail-branch-threshold-scope; src/handles/{api.ts,index.ts,UTxO.ts,constants.ts,policies.ts,models/**,interfaces/{api.ts,ScriptDetails.ts}}:runtime-and-model-surfaces-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/utils/{index.ts,crypto/**,common.ts,contract.ts,cbor/index.ts}:broader-runtime-helpers-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/index.ts:package-entry-surface-not-branch-measured
+SOURCE_PATHS=src/constants/{contractsRegistry.ts,mintedOgList.ts};src/errors/index.ts;src/handles/{api.ts,interfaces/index.ts};src/types/{index.ts,profile-header.ts};src/utils/cbor/schema/{designer.ts,handleData.ts,marketplaceDatum.ts,portal.ts,socials.ts,subHandleSettings.ts}
+EXCLUDED_PATHS=src/{environment/**,http/**,logger/**,marketplace/**,repositories/**,protectedWords/**}:covered-by-existing-unit-suites-but-not-in-guardrail-branch-threshold-scope; src/handles/{index.ts,UTxO.ts,constants.ts,policies.ts,models/**,interfaces/{api.ts,ScriptDetails.ts}}:runtime-and-model-surfaces-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/utils/{index.ts,crypto/**,common.ts,contract.ts,cbor/index.ts}:broader-runtime-helpers-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/index.ts:package-entry-surface-not-branch-measured
 LANGUAGE_SUMMARY=nodejs:lines=100,branches=100,tool=jest,status=pass
 
 === RAW_OUTPUT_NPM_TEST ===
 
-> @koralabs/kora-labs-common@6.4.17 test
+> @koralabs/kora-labs-common@6.6.2 test
 > NETWORK=mainnet node --experimental-vm-modules node_modules/.bin/jest
 
-(node:1195445) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895661) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195467) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895716) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195481) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895715) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195493) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895717) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195468) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895718) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195475) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895739) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195483) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195499) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195470) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-PASS src/utils/index.test.ts
-PASS src/utils/cbor/index.test.ts
-PASS src/errors/index.test.ts
-PASS src/logger/index.test.ts
 PASS src/http/index.test.ts
+PASS src/utils/index.test.ts
+PASS src/handles/api.test.ts
 PASS src/utils/crypto/crypto.test.ts
 PASS src/handles/utils.test.ts
-PASS src/protectedWords/index.test.ts
+PASS src/utils/cip8/index.test.ts
+PASS src/utils/cbor/index.test.ts
+PASS src/aws/kmsEnvironment.test.ts
+PASS src/errors/index.test.ts
+PASS src/logger/index.test.ts
+PASS src/protectedWords/index.test.ts (7.24 s)
 
-Test Suites: 8 passed, 8 total
-Tests:       67 passed, 67 total
+Test Suites: 11 passed, 11 total
+Tests:       99 passed, 99 total
 Snapshots:   0 total
-Time:        3.74 s, estimated 5 s
+Time:        7.448 s, estimated 8 s
 Ran all test suites.
 
 === RAW_OUTPUT_JEST_COVERAGE ===
-(node:1195782) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895787) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195808) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895866) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195815) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895879) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195814) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895865) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195833) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895867) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195807) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195821) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195827) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-(node:1195850) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
+(node:1895873) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
 (Use `node --trace-warnings ...` to show where the warning was created)
 PASS src/http/index.test.ts
-PASS src/logger/index.test.ts
-PASS src/handles/utils.test.ts
-PASS src/errors/index.test.ts
+PASS src/handles/api.test.ts
+PASS src/aws/kmsEnvironment.test.ts
 PASS src/utils/cbor/index.test.ts
-PASS src/utils/index.test.ts
 PASS src/utils/crypto/crypto.test.ts
-PASS src/protectedWords/index.test.ts
+PASS src/utils/cip8/index.test.ts
+PASS src/logger/index.test.ts
+PASS src/errors/index.test.ts
+PASS src/utils/index.test.ts
+PASS src/handles/utils.test.ts
+PASS src/protectedWords/index.test.ts (8.031 s)
 -----------------------|---------|----------|---------|---------|-------------------
 File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
 -----------------------|---------|----------|---------|---------|-------------------
@@ -84,6 +78,8 @@ All files              |     100 |      100 |     100 |     100 |
   mintedOgList.ts      |     100 |      100 |     100 |     100 |                   
  errors                |     100 |      100 |     100 |     100 |                   
   index.ts             |     100 |      100 |     100 |     100 |                   
+ handles               |     100 |      100 |     100 |     100 |                   
+  api.ts               |     100 |      100 |     100 |     100 |                   
  handles/interfaces    |     100 |      100 |     100 |     100 |                   
   index.ts             |     100 |      100 |     100 |     100 |                   
  types                 |     100 |      100 |     100 |     100 |                   
@@ -98,8 +94,8 @@ All files              |     100 |      100 |     100 |     100 |
   subHandleSettings.ts |     100 |      100 |     100 |     100 |                   
 -----------------------|---------|----------|---------|---------|-------------------
 
-Test Suites: 8 passed, 8 total
-Tests:       67 passed, 67 total
+Test Suites: 11 passed, 11 total
+Tests:       99 passed, 99 total
 Snapshots:   0 total
-Time:        3.91 s, estimated 4 s
+Time:        8.335 s
 Ran all test suites.

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -15,6 +15,7 @@ npm test > "$TMP_DIR/npm.test.log" 2>&1
 
 NETWORK=mainnet node --experimental-vm-modules node_modules/.bin/jest \
   --coverage \
+  --collectCoverageFrom='src/handles/api.ts' \
   --collectCoverageFrom='src/handles/interfaces/index.ts' \
   --collectCoverageFrom='src/types/index.ts' \
   --collectCoverageFrom='src/types/profile-header.ts' \
@@ -58,8 +59,8 @@ fi
   echo "TOTAL_LINES_PCT=$LINE_COVERAGE"
   echo "TOTAL_BRANCHES_PCT=$BRANCH_COVERAGE"
   echo "STATUS=$STATUS"
-  echo "SOURCE_PATHS=src/constants/{contractsRegistry.ts,mintedOgList.ts};src/errors/index.ts;src/handles/interfaces/index.ts;src/types/{index.ts,profile-header.ts};src/utils/cbor/schema/{designer.ts,handleData.ts,marketplaceDatum.ts,portal.ts,socials.ts,subHandleSettings.ts}"
-  echo "EXCLUDED_PATHS=src/{environment/**,http/**,logger/**,marketplace/**,repositories/**,protectedWords/**}:covered-by-existing-unit-suites-but-not-in-guardrail-branch-threshold-scope; src/handles/{api.ts,index.ts,UTxO.ts,constants.ts,policies.ts,models/**,interfaces/{api.ts,ScriptDetails.ts}}:runtime-and-model-surfaces-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/utils/{index.ts,crypto/**,common.ts,contract.ts,cbor/index.ts}:broader-runtime-helpers-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/index.ts:package-entry-surface-not-branch-measured"
+  echo "SOURCE_PATHS=src/constants/{contractsRegistry.ts,mintedOgList.ts};src/errors/index.ts;src/handles/{api.ts,interfaces/index.ts};src/types/{index.ts,profile-header.ts};src/utils/cbor/schema/{designer.ts,handleData.ts,marketplaceDatum.ts,portal.ts,socials.ts,subHandleSettings.ts}"
+  echo "EXCLUDED_PATHS=src/{environment/**,http/**,logger/**,marketplace/**,repositories/**,protectedWords/**}:covered-by-existing-unit-suites-but-not-in-guardrail-branch-threshold-scope; src/handles/{index.ts,UTxO.ts,constants.ts,policies.ts,models/**,interfaces/{api.ts,ScriptDetails.ts}}:runtime-and-model-surfaces-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/utils/{index.ts,crypto/**,common.ts,contract.ts,cbor/index.ts}:broader-runtime-helpers-covered-by-unit-suites-with-open-branch-gap-follow-ups; src/index.ts:package-entry-surface-not-branch-measured"
   echo "LANGUAGE_SUMMARY=nodejs:lines=$LINE_COVERAGE,branches=$BRANCH_COVERAGE,tool=jest,status=$LANGUAGE_STATUS"
   echo
   echo "=== RAW_OUTPUT_NPM_TEST ==="


### PR DESCRIPTION
Coverage rotation followed the repo-local Jest and test_coverage.sh harness. Added src/handles/api.test.ts for HandlesApi initialization, host selection, header behavior, handle validation, and policy patching; extended test_coverage.sh to measure src/handles/api.ts and refreshed test_coverage.report. Verification passed: bash test_coverage.sh reported line=100%, branch=100%, and npm test passed with 11 suites and 99 tests. Lesson updated: coverage-rotation-local-tooling-first.