### PR TITLE
Local RS256 JWT sign/verify primitive (KMS fallback) for self-hosting

### DIFF
--- a/src/aws/index.ts
+++ b/src/aws/index.ts
@@ -1,2 +1,3 @@
 export { decryptKmsCiphertext, hydrateKmsEnvironment, loadAfterHydratingKmsEnvironment } from './kmsEnvironment';
 export type { KmsClientLike } from './kmsEnvironment';
+export { signRs256, verifyRs256, isLocalJwtSigner } from './jwtSigner';

--- a/src/aws/jwtSigner.test.ts
+++ b/src/aws/jwtSigner.test.ts
@@ -1,0 +1,48 @@
+import { generateKeyPairSync } from 'crypto';
+import { signRs256, verifyRs256, isLocalJwtSigner } from './jwtSigner';
+
+describe('jwtSigner (local RS256, KMS fallback)', () => {
+    const ORIG = {
+        priv: process.env.JWT_PRIVATE_KEY,
+        pub: process.env.JWT_PUBLIC_KEY,
+        keyId: process.env.JWT_KEY_ID
+    };
+    afterEach(() => {
+        process.env.JWT_PRIVATE_KEY = ORIG.priv;
+        process.env.JWT_PUBLIC_KEY = ORIG.pub;
+        process.env.JWT_KEY_ID = ORIG.keyId;
+    });
+
+    it('signs and verifies with a local RSA private key (no AWS)', async () => {
+        const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        process.env.JWT_PRIVATE_KEY = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+        delete process.env.JWT_PUBLIC_KEY;
+        delete process.env.JWT_KEY_ID;
+
+        expect(isLocalJwtSigner()).toBe(true);
+        const msg = Buffer.from('header.payload', 'utf-8');
+        const sig = await signRs256(msg);
+        expect(await verifyRs256(msg, sig)).toBe(true);
+        expect(await verifyRs256(Buffer.from('header.tampered', 'utf-8'), sig)).toBe(false);
+    });
+
+    it('accepts a base64-encoded PEM private key', async () => {
+        const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+        process.env.JWT_PRIVATE_KEY = Buffer.from(pem, 'utf-8').toString('base64');
+        delete process.env.JWT_PUBLIC_KEY;
+        delete process.env.JWT_KEY_ID;
+
+        const msg = Buffer.from('a.b', 'utf-8');
+        expect(await verifyRs256(msg, await signRs256(msg))).toBe(true);
+    });
+
+    it('falls back to requiring JWT_KEY_ID when no local key is configured', async () => {
+        delete process.env.JWT_PRIVATE_KEY;
+        delete process.env.JWT_PUBLIC_KEY;
+        delete process.env.JWT_KEY_ID;
+        expect(isLocalJwtSigner()).toBe(false);
+        await expect(signRs256(Buffer.from('x'))).rejects.toThrow('JWT_KEY_ID not configured');
+        await expect(verifyRs256(Buffer.from('x'), Buffer.from('y'))).rejects.toThrow('JWT_KEY_ID not configured');
+    });
+});

--- a/src/aws/jwtSigner.ts
+++ b/src/aws/jwtSigner.ts
@@ -1,0 +1,95 @@
+import { KMSClient, SignCommand, VerifyCommand } from '@aws-sdk/client-kms';
+import { createSign, createVerify, createPublicKey } from 'crypto';
+
+// RS256 (RSASSA_PKCS1_V1_5_SHA_256) sign/verify primitive shared by the JWT-issuing/
+// verifying services (auth.handle.me grant cookie, handle.me/minting session tokens).
+//
+// It PREFERS a LOCAL RSA key — for the self-hosted deployment with no AWS — and FALLS
+// BACK to AWS KMS (JWT_KEY_ID) when no local key is configured, so existing KMS-backed
+// deployments keep working byte-for-byte and adoption can be gradual.
+//
+//   JWT_PRIVATE_KEY  RSA private key (PEM, or base64-encoded PEM) — used to SIGN. The
+//                    public half is derived from it for verification, so a single shared
+//                    secret (the private key) is enough on every node.
+//   JWT_PUBLIC_KEY   (optional) RSA public key (PEM/base64) for verify-only nodes that
+//                    should not hold the private key.
+//   JWT_KEY_ID       AWS KMS key id/alias (legacy fallback when no local key is set).
+//
+// These callers sign/verify over different bytes (auth signs the payload only; the
+// session-token path signs `header.payload`), so this stays a low-level bytes-in/bytes-out
+// primitive — each service keeps building its own token exactly as before.
+
+const SIGNING_ALGORITHM = 'RSASSA_PKCS1_V1_5_SHA_256';
+
+let _kms: KMSClient | undefined;
+const kms = (): KMSClient => (_kms ??= new KMSClient({}));
+
+// Accept a raw PEM or a base64-encoded PEM (single-line, env-friendly).
+const pemFromEnv = (value?: string): string | undefined => {
+    if (!value) return undefined;
+    if (value.includes('-----BEGIN')) return value;
+    try {
+        const decoded = Buffer.from(value, 'base64').toString('utf-8');
+        return decoded.includes('-----BEGIN') ? decoded : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const localPrivateKey = (): string | undefined => pemFromEnv(process.env.JWT_PRIVATE_KEY);
+const localPublicKey = (): string | undefined => {
+    const pub = pemFromEnv(process.env.JWT_PUBLIC_KEY);
+    if (pub) return pub;
+    const priv = localPrivateKey();
+    if (!priv) return undefined;
+    return createPublicKey(priv).export({ type: 'spki', format: 'pem' }).toString();
+};
+
+/** True when a local RSA key is configured (i.e. signing/verifying needs no AWS). */
+export const isLocalJwtSigner = (): boolean => !!localPrivateKey() || !!pemFromEnv(process.env.JWT_PUBLIC_KEY);
+
+/** Sign `message` with RS256 — local private key if present, else AWS KMS. */
+export const signRs256 = async (message: Buffer): Promise<Buffer> => {
+    const priv = localPrivateKey();
+    if (priv) {
+        const signer = createSign('RSA-SHA256');
+        signer.update(message);
+        signer.end();
+        return signer.sign(priv);
+    }
+    const keyId = process.env.JWT_KEY_ID;
+    if (!keyId) throw new Error('JWT_KEY_ID not configured');
+    const response = await kms().send(
+        new SignCommand({
+            KeyId: keyId,
+            Message: new Uint8Array(message),
+            MessageType: 'RAW',
+            SigningAlgorithm: SIGNING_ALGORITHM
+        })
+    );
+    if (!response.Signature) throw new Error('KMS sign returned no signature');
+    return Buffer.from(response.Signature);
+};
+
+/** Verify an RS256 `signature` over `message` — local public key if present, else AWS KMS. */
+export const verifyRs256 = async (message: Buffer, signature: Buffer): Promise<boolean> => {
+    const pub = localPublicKey();
+    if (pub) {
+        const verifier = createVerify('RSA-SHA256');
+        verifier.update(message);
+        verifier.end();
+        return verifier.verify(pub, signature);
+    }
+    const keyId = process.env.JWT_KEY_ID;
+    if (!keyId) throw new Error('JWT_KEY_ID not configured');
+    const response = await kms().send(
+        new VerifyCommand({
+            KeyId: keyId,
+            Message: new Uint8Array(message),
+            MessageType: 'RAW',
+            Signature: new Uint8Array(signature),
+            SigningAlgorithm: SIGNING_ALGORITHM
+        })
+    );
+    return !!response.SignatureValid;
+};


### PR DESCRIPTION
Adds `signRs256(bytes)` / `verifyRs256(bytes,sig)` (+ `isLocalJwtSigner`) in `src/aws/jwtSigner.ts`: RS256 (RSASSA_PKCS1_V1_5_SHA_256) using a **local RSA key** (`JWT_PRIVATE_KEY`, PEM or base64-PEM; public derived from it, or `JWT_PUBLIC_KEY` for verify-only nodes) — so the JWT services need **no AWS** in the self-hosted deployment — and **falling back to AWS KMS** (`JWT_KEY_ID`) byte-for-byte when no local key is set, so existing KMS deployments keep working and adoption is gradual.

Low-level bytes-in/bytes-out so each caller keeps its exact token format (auth signs the payload only; handle.me/minting sign `header.payload`). Unit-tested (local round-trip, base64-PEM, KMS-fallback error); `tsc` builds.

Part of the AWS-exit migration (replaces the KMS JWT key `alias/auth-jwt1`). **Merge/publish this first** — the consumer PRs (auth.handle.me, handle.me, minting.handle.me) import these symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)