### PR TITLE
Fn↔Express bridge (invokeExpressViaAlb) for the self-hosted runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.6.2",
+    "version": "6.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@koralabs/kora-labs-common",
-            "version": "6.6.2",
+            "version": "6.7.0",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-kms": "^3.1003.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.6.4",
+    "version": "6.7.0",
     "description": "Kora Labs Common Utilities",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/fn/index.test.ts
+++ b/src/fn/index.test.ts
@@ -1,0 +1,63 @@
+import { invokeExpressViaAlb, type AlbHandler, type FnContext } from './index';
+
+// Minimal stand-in for the Fn FDK HTTPGatewayContext.
+const makeCtx = (requestURL: string, method: string, headers: Record<string, string | string[]> = {}) => {
+    const responseHeaders: Record<string, string[]> = {};
+    const gw = {
+        requestURL,
+        method,
+        headers,
+        statusCode: 0,
+        setResponseHeader: (k: string, ...v: string[]) => { responseHeaders[k.toLowerCase()] = v; },
+        addResponseHeader: (k: string, ...v: string[]) => { (responseHeaders[k.toLowerCase()] ??= []).push(...v); }
+    };
+    return { ctx: { httpGateway: gw } as FnContext, gw, responseHeaders };
+};
+
+describe('invokeExpressViaAlb (Fn <-> ALB bridge)', () => {
+    it('builds an ALB event from the Fn request and maps the ALB response back', async () => {
+        let seen: any;
+        const handler: AlbHandler = (event) => {
+            seen = event;
+            return {
+                statusCode: 201,
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ ok: true }),
+                isBase64Encoded: false
+            };
+        };
+        const { ctx, gw, responseHeaders } = makeCtx('/handles?a=1&a=2&b=x', 'GET', { 'X-Test': 'yes' });
+
+        const body = await invokeExpressViaAlb(handler, ctx);
+
+        // ALB event shape the app's serverless-express handler expects.
+        expect(seen.requestContext.elb).toBeDefined();
+        expect(seen.httpMethod).toBe('GET');
+        expect(seen.path).toBe('/handles');
+        expect(seen.queryStringParameters).toEqual({ a: '2', b: 'x' });
+        expect(seen.multiValueQueryStringParameters).toEqual({ a: ['1', '2'], b: ['x'] });
+        expect(seen.headers['x-test']).toBe('yes');
+
+        // Response mapped back onto the Fn gateway.
+        expect(gw.statusCode).toBe(201);
+        expect(responseHeaders['content-type']).toEqual(['application/json']);
+        expect(body).toBe(JSON.stringify({ ok: true }));
+    });
+
+    it('round-trips a base64 (binary) request body to the handler and decodes a base64 response', async () => {
+        const handler: AlbHandler = (event) => ({
+            statusCode: 200,
+            // echo the decoded request body back, base64-encoded
+            body: Buffer.from(event.body!, 'base64').toString('utf-8'),
+            isBase64Encoded: false
+        });
+        const { ctx } = makeCtx('/echo', 'POST');
+        const body = await invokeExpressViaAlb(handler, ctx, Buffer.from('hello-fn', 'utf-8'));
+        expect(body).toBe('hello-fn');
+    });
+
+    it('throws if the function was not HTTP-triggered', async () => {
+        const handler: AlbHandler = () => ({ statusCode: 200 });
+        await expect(invokeExpressViaAlb(handler, {} as FnContext)).rejects.toThrow('httpGateway');
+    });
+});

--- a/src/fn/index.ts
+++ b/src/fn/index.ts
@@ -1,0 +1,115 @@
+// Fn <-> Express bridge for the self-hosted runtime (MIGRATION-PLAN §4).
+//
+// Each app already exposes an @vendia/serverless-express ALB handler (e.g.
+// lambdas/api.app.ts `handler(event, ctx)`), which is how it ran on Lambda/ALB. Rather
+// than invent a new req/res bridge, `invokeExpressViaAlb` adapts an Fn HTTP-trigger
+// invocation INTO an ALB event, calls that existing handler, and maps the ALB response
+// back to Fn. So the Fn function reuses the exact Express request handling the app already
+// has, and apps need only a tiny func.js entrypoint:
+//
+//   const fdk = require('@fnproject/fdk');
+//   const { handler } = require('./dist/lambdas/api.app');           // the app's ALB handler
+//   const { invokeExpressViaAlb } = require('@koralabs/kora-labs-common');
+//   fdk.handle((input, ctx) => invokeExpressViaAlb(handler, ctx, input), { inputMode: 'buffer' });
+//
+// Typed loosely (no @types/aws-lambda / @fnproject/fdk dependency here) — the shapes below
+// match the ALB event/result and the Fn HTTPGatewayContext.
+
+interface AlbEvent {
+    requestContext: { elb: { targetGroupArn: string } };
+    httpMethod: string;
+    path: string;
+    queryStringParameters: Record<string, string> | null;
+    multiValueQueryStringParameters?: Record<string, string[]> | null;
+    headers: Record<string, string>;
+    body: string | null;
+    isBase64Encoded: boolean;
+}
+
+interface AlbResult {
+    statusCode?: number;
+    statusDescription?: string;
+    headers?: Record<string, string | number | boolean>;
+    multiValueHeaders?: Record<string, Array<string | number | boolean>>;
+    body?: string;
+    isBase64Encoded?: boolean;
+}
+
+export type AlbHandler = (event: AlbEvent, context: Record<string, unknown>) => Promise<AlbResult> | AlbResult;
+
+export interface FnHttpGateway {
+    requestURL: string;
+    method: string;
+    headers: Record<string, string | string[]>;
+    statusCode: number;
+    setResponseHeader(key: string, ...values: string[]): void;
+    addResponseHeader(key: string, ...values: string[]): void;
+}
+
+export interface FnContext {
+    httpGateway?: FnHttpGateway;
+}
+
+const flattenHeaders = (h: Record<string, string | string[]> | undefined): Record<string, string> => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(h || {})) {
+        out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v);
+    }
+    return out;
+};
+
+/**
+ * Drive an app's ALB (serverless-express) handler from an Fn HTTP invocation.
+ * @param albHandler the app's existing @vendia/serverless-express handler
+ * @param ctx        the Fn FDK context (must be HTTP-triggered → ctx.httpGateway present)
+ * @param input      the request body (Buffer, with fdk inputMode 'buffer')
+ * @returns the response body (Buffer or string); status + headers are set on ctx.httpGateway
+ */
+export const invokeExpressViaAlb = async (
+    albHandler: AlbHandler,
+    ctx: FnContext,
+    input?: Buffer | Uint8Array | string
+): Promise<Buffer | string> => {
+    const h = ctx.httpGateway;
+    if (!h) throw new Error('invokeExpressViaAlb: ctx.httpGateway missing (the function must be HTTP-triggered)');
+
+    // requestURL may be a bare path (`/handles?x=1`) or absolute; URL() needs a base.
+    const url = new URL(h.requestURL, 'http://kora.local');
+    const qs: Record<string, string> = {};
+    const mqs: Record<string, string[]> = {};
+    for (const key of new Set(url.searchParams.keys())) {
+        const all = url.searchParams.getAll(key);
+        qs[key] = all[all.length - 1];
+        mqs[key] = all;
+    }
+
+    const bodyBuf = input == null
+        ? Buffer.alloc(0)
+        : Buffer.isBuffer(input) ? input : Buffer.from(input as Uint8Array);
+
+    const event: AlbEvent = {
+        requestContext: { elb: { targetGroupArn: 'arn:kora:fn' } }, // marks this as an ALB event
+        httpMethod: h.method,
+        path: url.pathname,
+        queryStringParameters: Object.keys(qs).length ? qs : null,
+        multiValueQueryStringParameters: Object.keys(mqs).length ? mqs : null,
+        headers: flattenHeaders(h.headers),
+        body: bodyBuf.length ? bodyBuf.toString('base64') : null,
+        isBase64Encoded: true
+    };
+
+    const res: AlbResult = (await albHandler(event, {})) || {};
+
+    h.statusCode = res.statusCode ?? 200;
+    if (res.headers) {
+        for (const [k, v] of Object.entries(res.headers)) h.setResponseHeader(k, String(v));
+    }
+    if (res.multiValueHeaders) {
+        for (const [k, arr] of Object.entries(res.multiValueHeaders)) {
+            for (const v of arr) h.addResponseHeader(k, String(v));
+        }
+    }
+
+    if (res.body == null) return '';
+    return res.isBase64Encoded ? Buffer.from(res.body, 'base64') : res.body;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './constants';
 export * from './aws';
 export { ComputeEnvironment, Environment } from './environment';
 export * from './errors';
+export * from './fn';
 export * from './handles';
 export * from './http';
 export { LogCategory, Logger } from './logger';


### PR DESCRIPTION
Adds `invokeExpressViaAlb` (`src/fn/`): the MIGRATION-PLAN §4 shim that lets each app run as an **Fn function** by reusing its existing `@vendia/serverless-express` ALB handler. It adapts an Fn HTTP-trigger invocation into an ALB event, calls the app's handler, and maps the ALB response back onto the Fn gateway — so the Fn function reuses the exact Express request handling the app had on Lambda/ALB.

Each app then needs only a 4-line `func.js`:
```js
const fdk = require('@fnproject/fdk');
const { handler } = require('./dist/lambdas/api.app');
const { invokeExpressViaAlb } = require('@koralabs/kora-labs-common');
fdk.handle((input, ctx) => invokeExpressViaAlb(handler, ctx, input), { inputMode: 'buffer' });
```

Loose-typed (no `@types/aws-lambda` / `@fnproject/fdk` dep). Unit-tested (ALB event shape, multi-value query, header flatten, base64 body round-trip, response mapping, HTTP-trigger guard); builds. No change to existing exports.

Part of standing up the self-hosted **Preview** environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)