### PR TITLE
feat(#938): browser-safe WalletHandle/Asset/BasicAsset contracts

### DIFF
--- a/src/handles/interfaces/WalletHandle.ts
+++ b/src/handles/interfaces/WalletHandle.ts
@@ -1,0 +1,29 @@
+// Browser-safe wallet/asset contracts (handle.me#938). Self-contained — NO runtime/backend
+// imports — so ESM consumers like @koralabs/handles-shared-lit-components can use them (via
+// `import type`) without the CJS/ESM interop break the package's heavier modules would cause.
+// These canonicalize the duplicated local shapes in handles-shared-lit-components.
+
+export interface BasicAsset {
+    policyId: string;
+    hex: string;
+}
+
+export interface Asset extends BasicAsset {
+    name: string;
+    count?: number;
+    utxo?: string;
+    image?: string;
+    src?: string;
+    price?: number;
+    cost?: number;
+    validUntilDate?: number;
+}
+
+export interface WalletHandle extends Asset {
+    // `active` was `any` in shared-lit's local dupe and is not read by the shared components;
+    // `unknown` here keeps it in the contract while forcing consumers to narrow it explicitly.
+    active: unknown;
+    default: boolean;
+    image?: string;
+    imageUrl?: string;
+}

--- a/src/handles/interfaces/index.ts
+++ b/src/handles/interfaces/index.ts
@@ -544,3 +544,5 @@ export type MintHandleSettings = [
     MintHandleSettingsAsset[], // assets
     MintHandleSettingsDetails
 ];
+
+export * from './WalletHandle';


### PR DESCRIPTION
Step 1 of handle.me#938. Adds canonical browser-safe `WalletHandle`/`Asset`/`BasicAsset` (self-contained, no runtime/backend imports) so `@koralabs/handles-shared-lit-components` (ESM) can `import type` them — type-only imports erase at compile time, sidestepping the CJS/ESM interop break. `active` (was `any`, unread by the components) → `unknown`. tsc clean.

Once this publishes, the follow-up shared-lit PR bumps the dep + replaces the local duplicate with `import type { WalletHandle } from '@koralabs/kora-labs-common'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)