### PR TITLE
chore(release): 6.7.6 — publish browser-safe wallet types (#938)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koralabs/kora-labs-common",
-  "version": "6.7.5",
+  "version": "6.7.6",
   "description": "Kora Labs Common Utilities",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
#39 added `WalletHandle`/`Asset`/`BasicAsset` but didn't bump the version, so the deploy's npm publish failed (`cannot publish over 6.7.5`) and the types never reached npm. Version-only bump → the deploy publishes 6.7.6. Unblocks handle.me#938 step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)