### PR TITLE
fix: resolve npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.9.3",
+    "version": "6.9.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@koralabs/kora-labs-common",
-            "version": "6.9.3",
+            "version": "6.9.4",
             "license": "ISC",
             "dependencies": {
                 "@aws-sdk/client-kms": "^3.1003.0",
@@ -4509,16 +4509,6 @@
                 }
             }
         },
-        "node_modules/@jest/reporters/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/@jest/reporters/node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -7329,16 +7319,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -7983,11 +7963,14 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/base-x": {
             "version": "5.0.1",
@@ -8073,14 +8056,16 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -8383,13 +8368,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -9611,16 +9589,6 @@
                 }
             }
         },
-        "node_modules/jest-config/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/jest-config/node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -9972,16 +9940,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-runtime/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/jest-runtime/node_modules/glob": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -10182,9 +10140,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koralabs/kora-labs-common",
-    "version": "6.9.3",
+    "version": "6.9.4",
     "description": "Kora Labs Common Utilities",
     "main": "index.js",
     "types": "index.d.ts",
@@ -63,7 +63,8 @@
         "pluralize-esm": "^9.0.5"
     },
     "overrides": {
-        "js-yaml": "^4.2.0"
+        "js-yaml": "4.3.0",
+        "brace-expansion": "5.0.8"
     },
     "peerDependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.2.0"


### PR DESCRIPTION
Resolves the npm audit findings by pinning patched transitive versions for brace-expansion and js-yaml, refreshing package-lock.json, and bumping @koralabs/kora-labs-common to 6.9.4.

Validation passed:
- npm install
- npm audit --json
- npm run build
- npm test